### PR TITLE
added rhel8. Removed centos6 and trusty. New tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Configure system and normal groups and users. This role configures the following
 Version
 -------
 
+* `1.5.0` --- added RHEL8 Removed CentOS6 and Ubuntu 14.04
 * `1.4.0` --- added option for creating and removing arbitrary groups
 * `1.3.0` --- remove ubuntu precise from testing
 * `1.2.0` --- updated with ubuntu focal
@@ -32,13 +33,12 @@ Requirements
 
 This role is limited to:
 
-* Ubuntu 14.04
 * Ubuntu 16.04
 * Ubuntu 18.04
 * Ubuntu 20.04
-* CentOS 6
 * CentOS 7
 * CentOS 8
+* RHEL 8
 
 Role Variables
 --------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,15 +10,15 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-      - 12.04
-      - 14.04
       - 16.04
       - 18.04
       - 20.04
   - name: CentOS
     versions:
-      - 6
       - 7
+      - 8
+  - name: RHEL
+    versions:
       - 8
 
   galaxy_tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,13 @@
 ---
 - name: check if we're running supported os
   assert:
-    fail_msg: "{{ role_name }} only supports ubuntu versions 12, 14, 16, 18 and centos versions 6, 7!"
+    fail_msg: "{{ role_name }} only supports ubuntu versions 16, 18, 20 and centos versions 6, 7!"
     success_msg: "{{ role_name }} supports {{ ansible_distribution }} version {{ ansible_distribution_version }}"
     quiet: "{{ not ansible_check_mode }}"
     that:
-      ( ansible_distribution == "Ubuntu" and ansible_distribution_version|int in [12, 14, 16, 18, 20] )
-      or ( ansible_distribution == "CentOS" and ansible_distribution_major_version|int in [6, 7, 8] )
+      ( ansible_distribution == "Ubuntu" and ansible_distribution_version|int in [16, 18, 20] )
+      or ( ansible_distribution == "CentOS" and ansible_distribution_major_version|int in [7, 8] )
+      or ( ansible_distribution|lower == "redhat" and ansible_distribution_major_version|int in [8] )
 
 - name: list of enabled users
   set_fact:

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -8,10 +8,9 @@ Vagrant.configure("2") do |config|
     { :name => "focal", :box => "ubuntu/focal64" },
     { :name => "bionic", :box => "ubuntu/bionic64" },
     { :name => "xenial", :box => "ubuntu/xenial64" },
-    { :name => "trusty", :box => "ubuntu/trusty64" },
     { :name => "centos8", :box => "centos/8" },
     { :name => "centos7", :box => "centos/7" },
-    { :name => "centos6", :box => "centos/6" },
+    { :name => "rhel8", :box => "generic/rhel8" },
   ]
   boxes.each do |opts|
     config.vm.define opts[:name] do |config|


### PR DESCRIPTION
Hi!

Added support for rhel8.
removed support for centos6 and ubuntu 14.04

[Description]

I confirm that my contributions will be compatible with the GPLv2.0 license guidelines.

* [ ] I have read and accepted both license and code of conduct.
* [ ] I have previously accepted and still accept both license and code of conduct.
