### PR TITLE
Password nolock

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,4 @@
 skip_list:
   - role-name
+exclude_paths:
+  - .github

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,9 +12,3 @@ jobs:
 
       - name: Lint Ansible Playbook
         uses: ansible/ansible-lint-action@main
-        with:
-          targets: ""
-          # override-deps: |
-          #   ansible==2.9
-          #   ansible-lint==4.2.0
-          args: ""

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,6 +1,6 @@
 name: Ansible Lint
 
-on: [push, pull_request]
+on: [push, pull_request] # noqua
 
 jobs:
   build:
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@main
-      with:
-        targets: ""
-        #override-deps: |
-        #  ansible==2.9
-        #  ansible-lint==4.2.0
-        args: ""
+      - name: Lint Ansible Playbook
+        uses: ansible/ansible-lint-action@main
+        with:
+          targets: ""
+          # override-deps: |
+          #   ansible==2.9
+          #   ansible-lint==4.2.0
+          args: ""

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Configure system and normal groups and users. This role configures the following
 Version
 -------
 
+* `2.1.0` --- added `password_nolock`, for situations we're not changing password
 * `2.0.1` --- bug fix, ansible-lint
 * `2.0.0` --- updated to ansible 2.12.9
 * `1.7.0` --- added RHEL9 and CentOS Stream 8 support
@@ -75,6 +76,7 @@ Role Variables
     * `group` --- users main group, default username
     * `key` --- file with one ssh key on each line, default `''`
     * `password` --- set password hash for user - create new password with `mkpasswd -m sha512crypt`, default not set
+    * `password_nolock` --- don't lock password even if it is empty or not defined, default `false`
     * `remove` --- remove user files when `enabled == false`, default `false`
     * `restrict` --- subset of restrictions, default `user_default_restrict`
     * `shell` --- set user default shell, default `bash`

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
     groups: '{{ item.groups | default([]) }}'
     name: '{{ item.user }}'
     password: '{{ item.password | default(omit) }}'
-    password_lock: '{{ true if item.password is not defined and not password_nolock | default(false) else false }}'
+    password_lock: '{{ true if item.password is not defined and not item.password_nolock | default(false) else false }}'
     remove: '{{ item.remove | default(false) }}'
     shell: '{{ item.shell | default("/bin/bash") }}'
     state: '{{ "present" if item.enabled | default(false) else "absent" }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
     groups: '{{ item.groups | default([]) }}'
     name: '{{ item.user }}'
     password: '{{ item.password | default(omit) }}'
-    password_lock: '{{ true if item.password is not defined else false }}'
+    password_lock: '{{ true if item.password is not defined and not password_nolock | default(false) else false }}'
     remove: '{{ item.remove | default(false) }}'
     shell: '{{ item.shell | default("/bin/bash") }}'
     state: '{{ "present" if item.enabled | default(false) else "absent" }}'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,3 +13,18 @@
       user_default_allow_ips:
         - 0.0.0.0/0
       user_default_restrict: restrict,pty
+
+    - role: ../../.
+      user_groups: []
+      user_users:
+        - user: user2
+          enabled: true
+          password_nolock: true
+          allow_ips:
+            - 172.16.0.27/24
+
+        - user: user6
+          enabled: true
+          password_nolock: true
+          allow_ips:
+            - 172.16.0.27/24


### PR DESCRIPTION
Hi!

I'd like to contribute feature.

Role automatically locks password if it's not defined. If we want to update ssh-keys but keep password we need a way to tell the role not to lock the existing password. Added an option `password_nolock` that ensures we're not locking existing passwords. Default is `false` and should not change the default behaviour of the role.

I confirm that my contributions will be compatible with the GPLv2.0 license guidelines.

* [x] I have read and accepted both license and code of conduct.
* [x] I have previously accepted and still accept both license and code of conduct.
